### PR TITLE
Update Plugin version 0.0.2

### DIFF
--- a/kodi/plugin.video.tdtiberia/addon.py
+++ b/kodi/plugin.video.tdtiberia/addon.py
@@ -2,39 +2,18 @@ import sys
 import xbmcgui
 import xbmcplugin
 
-import urllib2
-from urlparse import urlparse
-from string import whitespace
-
-def uri_validator(x):
-    try:
-        result = urlparse(x)
-        return result.scheme and result.netloc and result.path
-    except:
-        return False
+import channelproviders
 
 addon_handle = int(sys.argv[1])
 xbmcplugin.setContent(addon_handle, 'movies')
 
-response = urllib2.urlopen('https://raw.githubusercontent.com/ruvelro/TV-Online-TDT-Spain/master/README.md')
-html = response.read()
-# TODO: this could fail, handle the error
+# provider = channelproviders.TvOnlineAPP()
+provider = channelproviders.GitHubMD()
 
-# Parse the readme.md
-# get to the list
-header, channelList = html.split('--- | ---')
+channelList = provider.retrieveList()
 
-# Split for each row
-for channel in channelList.split('\n'):
-	# This delimits a element in the list
-	if '|' in channel:	
-		channelName , channelURL = channel.split('|')
-		# Remove annoying first space
-		channelURL=channelURL[1:]
-		# If we can set some day any icon ...
-		# li = xbmcgui.ListItem('My First Video!', iconImage='DefaultVideo.png')
-		if uri_validator(channelURL):
-			channelListItem = xbmcgui.ListItem(channelName)
-			xbmcplugin.addDirectoryItem(handle=addon_handle, url=channelURL, listitem=channelListItem)
+for channel in channelList:
+	channelListItem = xbmcgui.ListItem(channel[0])
+	xbmcplugin.addDirectoryItem(handle=addon_handle, url=channel[1], listitem=channelListItem)
 
 xbmcplugin.endOfDirectory(addon_handle)

--- a/kodi/plugin.video.tdtiberia/addon.xml
+++ b/kodi/plugin.video.tdtiberia/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.tdtiberia" name="TDT Iberia" version="0.0.1" provider-name="urnenfeld">
+<addon id="plugin.video.tdtiberia" name="TDT Iberia" version="0.0.2" provider-name="urnenfeld">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
   </requires>

--- a/kodi/plugin.video.tdtiberia/channelproviders.py
+++ b/kodi/plugin.video.tdtiberia/channelproviders.py
@@ -9,7 +9,6 @@ def uri_validator(x):
     except:
         return False
 
-
 def similar(a, b):
     return SequenceMatcher(None, a, b).ratio() > 0.8
 
@@ -46,8 +45,6 @@ class GitHubMD:
                 channelName , channelURL = channel.split('|')
                 # Remove annoying first space
                 channelURL=channelURL[1:]
-                # If we can set some day any icon ...
-                # li = xbmcgui.ListItem('My First Video!', iconImage='DefaultVideo.png')
                 if uri_validator(channelURL):
                     processedChannelList.append([channelName, channelURL])
         

--- a/kodi/plugin.video.tdtiberia/channelproviders.py
+++ b/kodi/plugin.video.tdtiberia/channelproviders.py
@@ -1,0 +1,70 @@
+import urllib2
+from urlparse import urlparse
+from difflib import SequenceMatcher
+
+def uri_validator(x):
+    try:
+        result = urlparse(x)
+        return result.scheme and result.netloc and result.path
+    except:
+        return False
+
+
+def similar(a, b):
+    return SequenceMatcher(None, a, b).ratio() > 0.8
+
+class TvOnlineAPP:
+    URL = "http://www.apps4two.com/apps/tvonline/ch_channel.php"
+    def __init__(self):
+        response = urllib2.urlopen(self.URL)
+        self.responseText = response.read()
+        self.channelList = list(eval(self.responseText))
+
+    def retrieveList(self):
+        processedChannelList = []
+        for channel in self.channelList:
+            processedChannelList.append([channel[5], channel[7].replace('\/','/')])
+        return processedChannelList
+
+
+class GitHubMD:
+    URL = "https://raw.githubusercontent.com/ruvelro/TV-Online-TDT-Spain/master/README.md"
+    def __init__(self):
+        response = urllib2.urlopen(self.URL)
+        self.responseText = response.read()
+        
+    def retrieveList(self):
+        processedChannelList = []
+        # Parse the readme.md
+        # get to the list
+        header, channelList = self.responseText.split('--- | ---')
+
+        # Split for each row
+        for channel in channelList.split('\n'):
+            # This delimits a element in the list
+            if '|' in channel:	
+                channelName , channelURL = channel.split('|')
+                # Remove annoying first space
+                channelURL=channelURL[1:]
+                # If we can set some day any icon ...
+                # li = xbmcgui.ListItem('My First Video!', iconImage='DefaultVideo.png')
+                if uri_validator(channelURL):
+                    processedChannelList.append([channelName, channelURL])
+        
+        return processedChannelList
+
+''' Method for comparing the information provided by 2 channel providers '''
+def CheckChannelList(list1, list2):
+    for channel in list1:
+        for searchchannel in list2:
+            if similar(channel[0], searchchannel[0]) and channel[1] != searchchannel[1]:
+                print("\nChannel description matches for \""+channel[0]+"\" and \""+searchchannel[0]+"\" But URL...")
+                print("\t"+ channel[1])
+                print("\t"+ searchchannel[1])
+
+
+if __name__ == "__main__":
+    cp1 = TvOnlineAPP()
+    cp2 = GitHubMD()
+    
+    CheckChannelList(cp1.retrieveList(), cp2.retrieveList())


### PR DESCRIPTION
Funcionalmente el plugin, no tenemos cambios visibles.

Pero internamente si hay cosas que nos pueden ayudar.

La generación de la lista de canales esta abstraida del codigo del plugin (channelproviders.py).
- Código mas limpio y portable. La lógica no tiene dependencias con xbmc.
- Ello nos permite probar la extracción de canales sin usar Kodi, sólo necesitamos invocar al interprete de python.
- He añadido la posibilidad de extraer los canales directamente desde el PHP (habría que (des)comentar las lineas 10 y 11 del plugin.
- channelproviders.py es posible ejecutarlo por línea de comandos. Éste usará ambas formas de obtener los canales (.md / .php) y realizará una comprobación si para los canales que hay en común, alguna de las URLs han cambiado. Es decir intenta realizar un listado donde aparecen URLs que potencialmente hayan podido ser actualizadas.
