### PR TITLE
Fix TVG link

### DIFF
--- a/tv-spain.json
+++ b/tv-spain.json
@@ -290,14 +290,14 @@
     "id": 42,
     "enabled": false,
     "name": "TVG Europa - Galicia (GA)",
-    "link_m3u8": "http://europa-crtvg.flumotion.com/crtvg/europa/chunks.m3u8",
+    "link_m3u8": "http://europa-crtvg.flumotion.com/playlist.m3u8",
     "link_logo": ""
   },
   {
     "id": 43,
     "enabled": false,
     "name": "TVG America - Galicia (GA)",
-    "link_m3u8": "http://america-crtvg.flumotion.com/crtvg/america/chunks.m3u8",
+    "link_m3u8": "http://america-crtvg.flumotion.com/playlist.m3u8",
     "link_logo": ""
   },
   {

--- a/tv-spain.json
+++ b/tv-spain.json
@@ -290,14 +290,14 @@
     "id": 42,
     "enabled": false,
     "name": "TVG Europa - Galicia (GA)",
-    "link_m3u8": "http://media3.crtvg.es/live/_definst_/tvge_2/playlist.m3u8",
+    "link_m3u8": "http://europa-crtvg.flumotion.com/crtvg/europa/chunks.m3u8",
     "link_logo": ""
   },
   {
     "id": 43,
     "enabled": false,
     "name": "TVG America - Galicia (GA)",
-    "link_m3u8": "http://media3.crtvg.es/live/_definst_/tvga_2/playlist.m3u8",
+    "link_m3u8": "http://america-crtvg.flumotion.com/crtvg/america/chunks.m3u8",
     "link_logo": ""
   },
   {

--- a/tvchecker
+++ b/tvchecker
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 status_ok=":green_heart:"
 status_dead=":red_circle:"

--- a/tvchecker
+++ b/tvchecker
@@ -15,7 +15,7 @@ Plugin Kodi: Comprime la carpeta plugin.video.tdtiberia en un fichero zip con es
 
 ## Status Update: **$(date +"%d-%m-%y")**
 
-Status| Description
+Status| Descripción
 --- | --- |
 $status_ok|OK
 $status_dead|Link no accesible


### PR DESCRIPTION
Hola,

hoy he invertido algún tiempo buscando un enlace para TVG, pero ninguno de los que he podido encontrar funciona (incluídos los de este repo). Al final he tenido que extraerlo directamente de las conexiones que hace el navegador durante la reproducción en directo desde http://www.crtvg.es/tvg/tvg-en-directo

En ambos casos (Europa y América) he elegido el link de mayor calidad, pero hay otros dos de calidad media y baja (ver http://europa-crtvg.flumotion.com/playlist.m3u8 y http://america-crtvg.flumotion.com/playlist.m3u8).

Espero que sea útil. Un saludo y feliz año!
Manu